### PR TITLE
Add clarkon_event_load_default_acf_fields filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Event manager based on Clarkson and ACF Pro.",
     "type": "library",
     "license": "GPL-3.0",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "authors": [
         {
             "name": "Level Level"

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -17,7 +17,10 @@ class Setup {
   public function __construct(){
     if($this->checkDependencies()){
       $this->createPostType();
-      $this->loadDefaultACFFields();
+	  if( apply_filters('clarkon_event_load_default_acf_fields', true) ) {
+		$this->loadDefaultACFFields();
+	  }
+	  
 	  add_filter( 'clarkson_twig_functions', array( $this, 'addClarksonTwigFunctions' ) );
     }
   }


### PR DESCRIPTION
Because this project, samenwerkenaanpleegzorg, doens't need all theses default field. 
We even define "Lokaties" completly different, so we need to unload these.