### PR TITLE
Use correct namespace for WP_Query object documentation.

### DIFF
--- a/src/EventController.php
+++ b/src/EventController.php
@@ -10,7 +10,7 @@ class EventController{
    * Generates a basic query object to be enhanced with additional filters
    * @method prepareQuery
    * @param  EventControllerOptions           $options Options for the base query
-   * @return WP_Query        Query object with post type, datetimes set.
+   * @return \WP_Query        Query object with post type, datetimes set.
    */
     public function prepareQuery($options = array()){
         $args = array();


### PR DESCRIPTION
Otherwise Psalm will fail with the following message:

 Expected type 'WP_Query'. Found 'Clarkson\EventManager\WP_Query'.intelephense(1006)