### PR TITLE
Uses correct param type for event options

### DIFF
--- a/src/EventController.php
+++ b/src/EventController.php
@@ -9,7 +9,7 @@ class EventController{
   /**
    * Generates a basic query object to be enhanced with additional filters
    * @method prepareQuery
-   * @param  EventControllerOptions           $options Options for the base query
+   * @param  array           $options Options for the base query
    * @return \WP_Query        Query object with post type, datetimes set.
    */
     public function prepareQuery($options = array()){


### PR DESCRIPTION
Otherwise a static analysis issue would pop up

```
ERROR: InvalidArgument - themes/ondernemen010/app/Gutenberg/acf_block_events.php:50:78 - Argument 1 of Clarkson\EventManager\EventController::prepareQuery expects Clarkson\EventManager\EventControllerOptions, non-empty-array<array-key, mixed> provided (see https://psalm.dev/004)
```