### PR TITLE
Use correct property type.

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -12,7 +12,7 @@ class Event extends Clarkson_Object{
   public static $type = 'clarkson_event';
 
   /**
-   * @var data Contains ACF field content
+   * @var array
    */
   public $data;
 


### PR DESCRIPTION
Use correct property for data array.

Otherwise the following issue would pop up:

ERROR: UndefinedDocblockClass - themes/ondernemen010/app/WordPress_Objects/clarkson_event.php:8:81 - Docblock-defined class, interface or enum named Clarkson\EventManager\data does not exist (see https://psalm.dev/200)